### PR TITLE
Fix deprecation warning

### DIFF
--- a/grape-attack.gemspec
+++ b/grape-attack.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "grape", ">= 0.16", "< 2.0"
   spec.add_dependency "redis-namespace", "~> 1.5"
   spec.add_dependency "activemodel", ">= 4.0"
-  spec.add_dependency "activesupport", ">= 4.0"
+  spec.add_dependency "activesupport", ">= 4.0", "< 7"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 end

--- a/lib/grape/attack/adapters/memory.rb
+++ b/lib/grape/attack/adapters/memory.rb
@@ -21,7 +21,7 @@ module Grape
         end
 
         def atomically(&block)
-          block.call
+          block.call(self)
         end
       end
     end

--- a/lib/grape/attack/adapters/redis.rb
+++ b/lib/grape/attack/adapters/redis.rb
@@ -6,8 +6,8 @@ module Grape
       class Redis
         attr_reader :broker
 
-        def initialize
-          @broker = ::Redis::Namespace.new("grape-attack:#{env}:thottle", redis: ::Redis.new(url: url))
+        def initialize(broker: ::Redis::Namespace.new("grape-attack:#{env}:thottle", redis: ::Redis.new(url: url)))
+          @broker = broker
         end
 
         def get(key)
@@ -29,7 +29,9 @@ module Grape
         end
 
         def atomically(&block)
-          broker.multi(&block)
+          broker.multi do |instance|
+            block.call(self.class.new(broker: instance))
+          end
         end
 
         private

--- a/lib/grape/attack/counter.rb
+++ b/lib/grape/attack/counter.rb
@@ -17,9 +17,9 @@ module Grape
       end
 
       def update
-        adapter.atomically do
-          adapter.incr(key)
-          adapter.expire(key, ttl_in_seconds)
+        adapter.atomically do |instance|
+          instance.incr(key)
+          instance.expire(key, ttl_in_seconds)
         end
       rescue ::Grape::Attack::StoreError
       end

--- a/lib/grape/attack/version.rb
+++ b/lib/grape/attack/version.rb
@@ -1,5 +1,5 @@
 module Grape
   module Attack
-    VERSION = "0.4.1"
+    VERSION = "0.5.0"
   end
 end


### PR DESCRIPTION
The latest version of the `redis` gem is issuing the below deprecation warning for the `multi` method being called with a block that doesn't accept args. https://github.com/clickfunnels2/grape-attack/blob/ff628c23f8e4a62887727c79f9dbc03dc6cdab50/lib/grape/attack/adapters/redis.rb#L31-L33.

```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.multi do
  redis.get("key")
end

should be replaced by

redis.multi do |pipeline|
  pipeline.get("key")
end

(called from /Users/aaric/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/redis-namespace-1.8.2/lib/redis/namespace.rb:530:in `namespaced_block'}
```

Changes in ActiveSupport 7 resulted in the following exception. Given there are no tests I did not feel comfortable making introducing the changes.  Locking the ActiveSupport version to less than 7 for now. I'll make an issue to capture the need to verify that work.

```
NameError:
  uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState
```