### PR TITLE
[OmbuLabs] Added support for rails 7.0

### DIFF
--- a/grape-attack.gemspec
+++ b/grape-attack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "grape", ">= 0.16", "< 2.0"
   spec.add_dependency "redis-namespace", "~> 1.5"
   spec.add_dependency "activemodel", ">= 4.0"
-  spec.add_dependency "activesupport", ">= 4.0", "< 7"
+  spec.add_dependency "activesupport", ">= 4.0", "< 7.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This is not a complete PR. This is an attempt to upgrade Rails for an internal clickfunnels app and we need to add support for Rails 7.0 in this gem.

From the comments here, https://github.com/clickfunnels2/grape-attack/pull/1, Rails 7 seem to be not working out of the box and this PR does not have a fix for the problem yet.

So do not merge this PR.